### PR TITLE
bug: fix to and `is_zero` in `sgn0_quintic_ext` function of gadget

### DIFF
--- a/src/gadgets/base_field.rs
+++ b/src/gadgets/base_field.rs
@@ -623,7 +623,7 @@ macro_rules! impl_circuit_builder_for_extension_degree {
                     // is_zero = is_zero && is_zero_i
 
                     // x or y = x + y - xy
-                    let is_zero_and_sign_i = self.and(is_zero_i, sign_i);
+                    let is_zero_and_sign_i = self.and(is_zero, sign_i);
                     let sign_and_is_zero_and_sign_i = self.and(sign, is_zero_and_sign_i);
                     let tmp = self.mul_const_add(
                         -GFp::ONE,


### PR DESCRIPTION
### Summary

Found this bug when running tests in https://github.com/Lagrange-Labs/mapreduce-plonky2/pull/42.

Reference [this algo doc](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-07#name-the-sgn0-function), and corresponding field function [quintic_ext_sgn0](https://github.com/Lagrange-Labs/plonky2-ecgfp5/blob/main/src/curve/base_field.rs#L85).